### PR TITLE
39 default args redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,14 @@ Copy the solr generated configuration in our local docker compose environment:
 
     cp -r /tmp/labcas/solr-home ./solr/confs/
 
+### Configure Environment Variables
 
+The following environment variables will need to be set in order for certain DAGs to function
+
+- `LABCAS_LOCAL_DATA_LAKE`
+  - Path to Local Directory acting as the Ingest Data Lake
+- `LABCAS_LOCAL_DATA_STAGE`
+  - Path to Local Directory acting as the Ingest Data Stage
 
 ### Launch the services
 

--- a/mwaa/dags/ingest.py
+++ b/mwaa/dags/ingest.py
@@ -1,3 +1,4 @@
+import os
 from airflow import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 from docker.types import Mount
@@ -5,29 +6,31 @@ from datetime import timedelta
 from airflow.utils.dates import days_ago
 from airflow.models.param import Param
 
+# Mount points can't be templated, must be statically loaded
+
+DEFAULT_DATA_LAKE_HOST_PATH = '/labcas_local'
+DEFAULT_DATA_STAGE_HOST_PATH = '/labcas_stage'
+
+DATA_LAKE_HOST_PATH = os.getenv('AIRFLOW_VAR_DATA_LAKE_HOST_PATH', DEFAULT_DATA_LAKE_HOST_PATH)
+DATA_STAGE_HOST_PATH = os.getenv('AIRFLOW_VAR_DATA_STAGE_HOST_PATH', DEFAULT_DATA_STAGE_HOST_PATH)
+
+DEFAULT_SOLR_URL = "http://solr:8983/solr/"
+DEFAULT_USERNAME = "thomas"
+DEFAULT_PUBLISH_ARGS = "--collection Autoantibody_Biomarkers --steps headers hash crawl updown compare publish"
+
 # Define DAG params using Param
-DATA_LAKE_HOST_PATH = Param(
-    default="/Users/loubrieu/Documents/edrn/labcas_local",
-    description="file path where the archive data, metadata, thumbnails, etc. are stored, as mounted inside the Docker container",
-    type="string"
-)
-DATA_STAGE_HOST_PATH = Param(
-    default="/Users/loubrieu/Documents/edrn/labcas_stage",
-    description="file path where the staging data is stored, as mounted inside the Docker container",
-    type="string"
-)
 SOLR_URL = Param(
-    default="http://solr:8983/solr/",
+    DEFAULT_SOLR_URL,
     description="URL for the Solr instance",
     type="string"
 )
 USERNAME = Param(
-    default="thomas",
+    DEFAULT_USERNAME,
     description="Username for the process (if needed)",
     type="string"
 )
 PUBLISH_ARGS = Param(
-    default="--collection Autoantibody_Biomarkers --steps headers hash crawl updown compare publish",
+    DEFAULT_PUBLISH_ARGS,
     description="Arguments to override the Docker CMD",
     type="string"
 )
@@ -36,23 +39,20 @@ PUBLISH_ARGS = Param(
 default_args = {
     'data_lake_host_path': DATA_LAKE_HOST_PATH,
     'data_stage_host_path': DATA_STAGE_HOST_PATH,
-    'solr_url': SOLR_URL,
-    'username': USERNAME,
-    'publish_args': PUBLISH_ARGS,
+    'solr_url': DEFAULT_SOLR_URL,
+    'username': DEFAULT_USERNAME,
+    'publish_args': DEFAULT_PUBLISH_ARGS,
 }
 
 # Instantiate the DAG
 with DAG(
     dag_id='ingest_dag',
-    default_args=default_args,
     description='A simple ingest DAG',
     schedule_interval=None,
     start_date=days_ago(1),
     catchup=False,
     tags=['example'],
     params={
-        'data_lake_host_path': DATA_LAKE_HOST_PATH,
-        'data_stage_host_path': DATA_STAGE_HOST_PATH,
         'solr_url': SOLR_URL,
         'username': USERNAME,
         'publish_args': PUBLISH_ARGS,
@@ -64,15 +64,15 @@ with DAG(
         network_mode='labcas',
         api_version='auto',
         auto_remove=True,
-        command=dag.params['publish_args'],  # Override CMD with publish_args param
+        command="{{ params.publish_args }}",  # Override CMD with publish_args param
         docker_url='unix://var/run/docker.sock',
-        mounts=[
-            Mount("/data_lake", dag.params['data_lake_host_path'], type='bind'),
-            Mount("/data_stage", dag.params['data_stage_host_path'], type='bind'),
+        mounts = [
+            Mount(target="/data_lake", source=DATA_LAKE_HOST_PATH, type='bind'),
+            Mount(target="/data_stage", source=DATA_STAGE_HOST_PATH, type='bind'),
         ],
         environment={
-            'solr': dag.params['solr_url'],
-            'username': dag.params['username'],
+            'solr': "{{ params.solr_url }}",
+            'username': "{{ params.username }}",
         }
     )
     # Add more tasks or dependencies as needed

--- a/mwaa/docker-compose-local.yml
+++ b/mwaa/docker-compose-local.yml
@@ -36,6 +36,10 @@ services:
       - LOAD_EX=n
       - EXECUTOR=Local
       - AWS_PROFILE=saml-pub
+      # Local Source Mount paths for ingest DAG
+      - "AIRFLOW_VAR_DATA_LAKE_HOST_PATH=${LABCAS_LOCAL_DATA_LAKE}"
+      - "AIRFLOW_VAR_DATA_STAGE_HOST_PATH=${LABCAS_LOCAL_DATA_STAGE}"
+
     logging:
       options:
         max-size: 10m


### PR DESCRIPTION
## 📜 Summary
This MR addresses a few key issues with the original DAG definition.

1) `default_args` was originally set using the `Param` type. This should be a basic literal.
2)  The `mounts` option in the DockerOperator does no accept templated parameters for the version we are currently using (3.10.1) in the local MWAA container. The variables need to be statically configured.
3) In order to address point 2, the DAG definition module now attempts to read in two environment variables
  - `AIRFLOW_VAR_DATA_LAKE_HOST_PATH`
  - `AIRFLOW_VAR_DATA_STAGE_HOST_PATH`

   This lets it be compatible with both environment variables configured through docker compose and with Airflow variables.
   The variables are expected to point to locally addressed directory paths.
    
   In order to populate these variables, the `mwaa/docker-compose-local.yml` has been modified to mirror these variables to variables configured on the local machine.

The following environment variables are now required to be exported within the local environment before launching the MWAA local compose instance.

- `LABCAS_LOCAL_DATA_LAKE`
- `LABCAS_LOCAL_DATA_STAGE`



## 🧩 Related Issues

- Fixes #39 
- Fixes #40 